### PR TITLE
Add Docker support with Dockerfile and .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+.git
+.gitignore
+Dockerfile
+README.md
+*.log

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+# Use the official PHP image with Apache
+FROM php:8.2-apache
+
+# Copy all project files to the Apache web root
+COPY . /var/www/html/
+
+# Give necessary permissions (optional)
+RUN chown -R www-data:www-data /var/www/html
+
+# Expose port 80
+EXPOSE 80
+
+# for PHP extensions like mysqli
+RUN docker-php-ext-install mysqli


### PR DESCRIPTION
Added Dockerfile and .dockerignore to containerize the PHP application.
- Dockerfile uses php:8.2-apache
- Exposes port 80
- Installs mysqli extension
- .dockerignore added to avoid unnecessary files in image